### PR TITLE
fix(auth): improve SuperTokens startup reliability

### DIFF
--- a/modules/auth/helm/templates/deployment-backend.yml
+++ b/modules/auth/helm/templates/deployment-backend.yml
@@ -127,6 +127,43 @@ spec:
       labels:
         app: supertokens
     spec:
+      initContainers:
+        - name: wait-for-postgres
+          image: postgres:15-alpine
+          command: ['sh', '-c']
+          args:
+            - |
+              until pg_isready -h ${POSTGRESQL_HOST} -p ${POSTGRESQL_PORT} -U ${POSTGRESQL_USER} -d ${POSTGRESQL_DATABASE_NAME}; do
+                echo "Waiting for PostgreSQL to be ready..."
+                sleep 2
+              done
+              echo "PostgreSQL is ready!"
+          env:
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.db.secret.name }}
+                  key: password
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.db.secret.name }}
+                  key: username
+            - name: POSTGRESQL_DATABASE_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.db.configmap }}
+                  key: POSTGRES_DB
+            - name: POSTGRESQL_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.db.configmap }}
+                  key: POSTGRES_HOST
+            - name: POSTGRESQL_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Values.db.configmap }}
+                  key: POSTGRES_PORT
       containers:
         - name: supertokens
           image: 'registry.supertokens.io/supertokens/supertokens-postgresql:{{ .Values.supertokens.image.tag }}'
@@ -165,6 +202,14 @@ spec:
 
             - name: ACCESS_TOKEN_VALIDITY
               value: "{{ .Values.supertokens.accessTokenValidity }}"
+
+          readinessProbe:
+            httpGet:
+              port: 3567
+              path: '/hello'
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 3
 
           startupProbe:
             httpGet:

--- a/modules/auth/helm/templates/deployment-db.yml
+++ b/modules/auth/helm/templates/deployment-db.yml
@@ -42,13 +42,25 @@ spec:
                 configMapKeyRef:
                   name: {{ .Values.db.configmap }}
                   key: POSTGRES_DB
-          livenessProbe:
-            initialDelaySeconds: 5
-            periodSeconds: 5
+
+          readinessProbe:
             exec:
               command:
-                - pg_isready
-                - -U
-                - $POSTGRES_USER
-                - -d
-                - $POSTGRES_DB
+                - /bin/sh
+                - -c
+                - pg_isready -U $POSTGRES_USER -d $POSTGRES_DB
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 3
+
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U $POSTGRES_USER -d $POSTGRES_DB
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3


### PR DESCRIPTION
- Add init container to SuperTokens deployment
  * Waits for PostgreSQL to be ready before starting SuperTokens
  * Uses pg_isready to verify database connectivity
  * Prevents startup race conditions between services

- Add readiness probe to SuperTokens container
  * Monitor /hello endpoint for service health
  * Improves startup detection and service reliability

- Enhance PostgreSQL health checks
  * Add proper readiness probe with pg_isready
  * Improve liveness probe configuration with timeouts
  * Use shell wrapper for better command execution

These changes resolve SuperTokens startup issues and eliminate database connection errors during service initialization without requiring credential changes.

Note: SuperTokens now uses both startupProbe and readinessProbe:
- startupProbe: handles initial startup (up to 5min for DB schema creation)
- readinessProbe: ensures service is ready for traffic after startup This prevents routing requests to pods still initializing their database.